### PR TITLE
Fix the type mismatch for CategoryProductField.touched.product

### DIFF
--- a/packages/bundles-dynamic/src/components/bundle-preview/category-product-field.js
+++ b/packages/bundles-dynamic/src/components/bundle-preview/category-product-field.js
@@ -183,7 +183,7 @@ CategoryProductField.propTypes = {
     }),
   }).isRequired,
   touched: PropTypes.shape({
-    product: PropTypes.bool,
+    product: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]),
     quantity: PropTypes.bool,
   }),
   errors: PropTypes.shape({


### PR DESCRIPTION
**Description**
type is actually `object` when it is defined as `boolean`
https://github.com/commercetools/commercetools-bundles-starter/issues/104

**Hints**
After changing to `object` in type definition, another warning message is thrown 
```
index.js:1 Warning: Failed prop type: Invalid prop `touched.product` of type `boolean` supplied to `CategoryProductField`, expected `object`.
```
For this reason, this fix is to define CategoryProductField.touched.product can be either `boolean` or `object` type