### PR TITLE
Fix build issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,12 @@ jobs:
         working-directory: packages/platform-extension-static-bundles
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v2
       - name: Use Node.js 14.x
         uses: actions/setup-node@v2
         with:
           node-version: '14.x'
+      - run: echo -e '[url "https://github.com/"]\n  insteadOf = "git://github.com/"' >> ~/.gitconfig
       - run: yarn
       - run: lerna run test:unit
       - run: lerna run test:integration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '14.x'
+      - run: echo -e '[url "https://github.com/"]\n  insteadOf = "git://github.com/"' >> ~/.gitconfig
       - run: yarn
       - run: lerna run test:unit
       - run: lerna run test:integration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,12 @@ concurrency: CI
 on: [push]
 
 jobs:
-  extension_static_bundles:
-    name: Extension static bundles
+  commercetools-bundles:
+    name: Commercetools bundles starter
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: packages/platform-extension-static-bundles
+        working-directory: packages
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,11 @@ jobs:
         working-directory: packages/platform-extension-static-bundles
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js 14.x
         uses: actions/setup-node@v2
         with:
           node-version: '14.x'
-      - run: echo -e '[url "https://github.com/"]\n  insteadOf = "git://github.com/"' >> ~/.gitconfig
       - run: yarn
       - run: lerna run test:unit
       - run: lerna run test:integration

--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
     ":pinOnlyDevDependencies",
     "schedule:weekly"
   ],
+  "automerge": true,
   "separateMajorMinor": true,
   "packageRules": [
     {


### PR DESCRIPTION
1) After this changes from Github here: https://github.blog/2021-09-01-improving-git-protocol-security-github/
Some of our dependencies are unable to download. 

Fixed this issue by changing the url to download, [here](https://github.com/actions/checkout/issues/14#issuecomment-523916396) for more details.

check here for more details: 
https://stackoverflow.com/questions/70663523/the-unauthenticated-git-protocol-on-port-9418-is-no-longer-supported

2) Enable auto merge for renovate PR's.